### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Forz70043/coin-pwa/security/code-scanning/1](https://github.com/Forz70043/coin-pwa/security/code-scanning/1)

To resolve the issue, we need to explicitly define the `permissions` key in the workflow YAML file. Following the principle of least privilege, the `contents` permission should be set to `read`, as this is typically sufficient for most workflows that do not modify repository contents. Additionally, since the workflow appears to upload coverage data to Coveralls, the `contents` permission should remain read-only unless write access is explicitly required for something like creating or updating files in the repository. 

The `permissions` key can be added at the root of the workflow to apply to all jobs or specifically under the `test` job if other jobs in the workflow (not shown here) require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
