### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
     "multer": "^2.0.1",
-    "mysql2": "^3.14.2"
+    "mysql2": "^3.14.2",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.1.10",

--- a/routes/coins.js
+++ b/routes/coins.js
@@ -2,6 +2,14 @@ const express = require('express');
 const router = express.Router();
 const db = require('../models/db');
 const multer = require('multer');
+const rateLimit = require('express-rate-limit');
+
+// Rate limiter for DELETE requests to protect DB and service
+const deleteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // limit each IP to 10 delete requests per windowMs
+  message: { error: 'Too many delete requests from this IP, please try again later.' }
+});
 
 // Configurazione multer
 const storage = multer.diskStorage({
@@ -67,7 +75,7 @@ router.put('/:id', upload.single('image'), async (req, res) => {
 });
 
 
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', deleteLimiter, async (req, res) => {
   const id = req.params.id;
 
   try {


### PR DESCRIPTION
Potential fix for [https://github.com/Forz70043/coin-pwa/security/code-scanning/5](https://github.com/Forz70043/coin-pwa/security/code-scanning/5)

To fix the issue, we should apply a rate-limiting middleware to the affected route to restrict the number of requests allowed in a given window. The best way to address this in Express is to use the `express-rate-limit` package, which is a well-known and actively maintained solution. We'll need to add the `express-rate-limit` import to the file, define a rate limiter (for example, max 10 delete requests per 15 minutes), and then attach this middleware specifically to the `DELETE /:id` route to avoid impacting other routes unnecessarily. All edits will be confined to `routes/coins.js`, including the new import and rate limiter definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
