### PR TITLE
Potential fix for code scanning alert no. 4: Missing rate limiting

### DIFF
--- a/routes/coins.js
+++ b/routes/coins.js
@@ -11,6 +11,13 @@ const deleteLimiter = rateLimit({
   message: { error: 'Too many delete requests from this IP, please try again later.' }
 });
 
+// Rate limiter for PUT requests to protect DB and service
+const putLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // limit each IP to 10 put requests per windowMs
+  message: { error: 'Too many update requests from this IP, please try again later.' }
+});
+
 // Configurazione multer
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
@@ -50,7 +57,7 @@ router.get('/', async (req, res) => {
 });
 
 
-router.put('/:id', upload.single('image'), async (req, res) => {
+router.put('/:id', putLimiter, upload.single('image'), async (req, res) => {
   const { type, country, year, denomination, mint_mark, material, grade } = req.body;
   const id = req.params.id;
   const image = req.file ? req.file.filename : null;


### PR DESCRIPTION
Potential fix for [https://github.com/Forz70043/coin-pwa/security/code-scanning/4](https://github.com/Forz70043/coin-pwa/security/code-scanning/4)

To fix the missing rate limiting for the `PUT /:id` endpoint, we should apply a suitable instance of the `express-rate-limit` middleware to this route, just as has been done for the `DELETE` route (with `deleteLimiter`). The most direct and maintainable solution is to define a new rate limiter for `PUT` operations, called for example `putLimiter`, with parameters appropriate for the expected usage pattern—likely similar to those for `DELETE`. Then, apply this limiter as middleware to the `router.put('/:id', ...)` handler. This involves:

- Defining a `putLimiter` using `rateLimit` with suitable options (e.g., `windowMs: 15 * 60 * 1000, max: 10`).
- Applying `putLimiter` as middleware to the `PUT /:id` route, just like `deleteLimiter` is applied to `DELETE /:id`.
- No import changes are needed, as `express-rate-limit` is already imported.
- The `putLimiter` definition should be placed just before the route definitions for code clarity, matching the style of the existing code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
