### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/routes/coins.js
+++ b/routes/coins.js
@@ -18,6 +18,13 @@ const putLimiter = rateLimit({
   message: { error: 'Too many update requests from this IP, please try again later.' }
 });
 
+// Rate limiter for GET requests to protect DB and service
+const getLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 get requests per windowMs
+  message: { error: 'Too many requests from this IP, please try again later.' }
+});
+
 // Configurazione multer
 const storage = multer.diskStorage({
   destination: (req, file, cb) => {
@@ -47,7 +54,7 @@ router.post('/', upload.single('image'), async (req, res) => {
   }
 });
 
-router.get('/', async (req, res) => {
+router.get('/', getLimiter, async (req, res) => {
   try {
     const [rows] = await db.execute('SELECT * FROM coins ORDER BY year DESC');
     res.json(rows);


### PR DESCRIPTION
Potential fix for [https://github.com/Forz70043/coin-pwa/security/code-scanning/3](https://github.com/Forz70043/coin-pwa/security/code-scanning/3)

To address the problem, a rate-limiting middleware should be added to the GET `'/'` route handler in routes/coins.js, similar to the PUT and DELETE routes. Since the PUT and DELETE requests are both limited to 10 requests per 15-minute window per IP, it is reasonable to create a separate rate limiter for GET requests, potentially with a higher limit if desired (since reads are typically less expensive than writes), but at a minimum, the same level of restriction can be applied for demonstration purposes. The most straightforward fix is to define a `getLimiter` near `putLimiter` and `deleteLimiter`, and then add it as middleware to the GET route on line 50. No changes are required in other files.

You will also need to ensure that the rate limiting messages (if exceeded) are user-friendly and consistent with the existing patterns. Add the new definition near the others.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
