### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/routes/coins.js
+++ b/routes/coins.js
@@ -18,6 +18,13 @@ const putLimiter = rateLimit({
   message: { error: 'Too many update requests from this IP, please try again later.' }
 });
 
+// Rate limiter for POST requests to protect DB and service
+const postLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20, // limit each IP to 20 post requests per windowMs
+  message: { error: 'Too many create requests from this IP, please try again later.' }
+});
+
 // Rate limiter for GET requests to protect DB and service
 const getLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
@@ -37,7 +44,7 @@ const storage = multer.diskStorage({
 });
 const upload = multer({ storage });
 
-router.post('/', upload.single('image'), async (req, res) => {
+router.post('/', postLimiter, upload.single('image'), async (req, res) => {
   const { type, country, year, denomination, mint_mark, material, grade } = req.body;
   const image = req.file ? req.file.filename : null;
 


### PR DESCRIPTION
Potential fix for [https://github.com/Forz70043/coin-pwa/security/code-scanning/2](https://github.com/Forz70043/coin-pwa/security/code-scanning/2)

The best way to fix the problem is to add a rate limiter middleware to the POST `/` route, just like for the GET, PUT, and DELETE routes. The most appropriate approach is to create a new rate limiter specifically for POST requests—tailoring the number of allowed requests to mitigate potential abuse (e.g., lower limit than GETs since POSTs are usually more resource-intensive)—and attach it as middleware to the route. This means: 

- Define a new `postLimiter` constant, similar to the existing `getLimiter`, `putLimiter`, and `deleteLimiter`, but with parameters suitable for POST rates.
- Apply `postLimiter` as a middleware to the POST route at line 40.
- Ensure the rate limiter is appropriately positioned *before* the multer middleware in the route stack, so rate-limited requests don't invoke file uploads unnecessarily.

No changes are needed elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
